### PR TITLE
Mzrf 65 - 도커 파일 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-alpine
+VOLUME /tmp
+COPY build/libs/api-restaurant-0.0.1-SNAPSHOT.jar api.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar", "api.jar"]

--- a/src/main/java/com/ddingji/apirestaurant/global/config/WebConfig.java
+++ b/src/main/java/com/ddingji/apirestaurant/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.ddingji.apirestaurant.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET","POST","PUT","PATCH","DELETE");
+    }
+}


### PR DESCRIPTION
### 개요 
도커를 이용하기 위해 도커 파일을 제작

### 사용 방법
도커가 깔려있다는 전제 하에 아래와 같은 커맨드를 입력
()는 optional
```
docker build -t (아이디/)원하는이름:태그 . -> 도커 파일 생성
docker run -d -p 8080:8080 이름:태그 -> 도커 실행 -d : 백그라운드 실행 -p : 왼쪽은 로컬포트, 오른쪽은 도커 포트 사이에서 연결
docker ps -> 현재 실행 중인 컨테이너 확인
docker images -> 이미지 리스트 확인
docker stop 도커아이디 or 도커 이름 ->  컨테이너 종료
```