### PR TITLE
도커 컴포즈 파일 생성 및 배포 버전 설정파일 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:17-alpine
 VOLUME /tmp
 COPY build/libs/api-restaurant-0.0.1-SNAPSHOT.jar api.jar
 EXPOSE 8080
-ENTRYPOINT ["java","-jar", "api.jar"]
+ENTRYPOINT ["java","-jar", "-Dspring.profiles.active=prod" , "api.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  my_redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+  ddingji-world-api:
+    image: kgh2120/ddingji-world:1.0.0
+    ports:
+      - 8080:8080
+    depends_on:
+      - my_redis

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,36 @@
+spring:
+  config:
+    activate:
+      on-profile: "prod"
+  datasource:
+    url:  jdbc:h2:mem:test;MODE=mysql;
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+    hikari:
+      connection-timeout: 5000 #timeout 5sec.
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    generate-ddl: true
+    show-sql: true
+    defer-datasource-initialization: true
+    properties:
+      hibernate:
+        format_sql: true
+        generate_statistics: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  sql:
+    init:
+      encoding: utf-8
+  cache:
+    type: redis
+    redis:
+      cache-null-values: true
+  data:
+    redis:
+      host: my_redis
+      port: 6379


### PR DESCRIPTION
도커 환경에서 도커끼리 연결하기 위한 도커 컴포즈 파일 생성 그리고 설정 파일 추가함.

### docker-compose.yml

```yml
version: '3'

services:
  my_redis:
    image: redis:latest
    ports:
      - 6379:6379
  ddingji-world-api:
    image: kgh2120/ddingji-world:1.0.0
    ports:
      - 8080:8080
    depends_on:
      - my_redis
```

### application-prod.yml
```yml
spring:
  config:
    activate:
      on-profile: "prod"
  datasource:
    url:  jdbc:h2:mem:test;MODE=mysql;
    driverClassName: org.h2.Driver
    username: sa
    password:
    hikari:
      connection-timeout: 5000 #timeout 5sec.
  jpa:
    hibernate:
      ddl-auto: create-drop
    generate-ddl: true
    show-sql: true
    defer-datasource-initialization: true
    properties:
      hibernate:
        format_sql: true
        generate_statistics: true
  h2:
    console:
      enabled: true
      path: /h2-console
  sql:
    init:
      encoding: utf-8
  cache:
    type: redis
    redis:
      cache-null-values: true
  data:
    redis:
      host: my_redis
      port: 6379
```